### PR TITLE
Discarding the master and slave vocabulary

### DIFF
--- a/mysql/v1/mysql.go
+++ b/mysql/v1/mysql.go
@@ -113,8 +113,8 @@ var Mappings = []*Mapping{
 		InExport: "last_",
 	},
 	{
-		OnServer: "Master_",
-		InExport: "master_",
+		OnServer: "Main_",
+		InExport: "main_",
 	},
 	{
 		OnServer: "Max_",
@@ -149,8 +149,8 @@ var Mappings = []*Mapping{
 		InExport: "select_",
 	},
 	{
-		OnServer: "Slave_",
-		InExport: "slave_",
+		OnServer: "Subordinate_",
+		InExport: "subordinate_",
 	},
 	{
 		OnServer: "Slow_",

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -256,7 +256,7 @@ func gatherInfoOutput(
 			}
 		}
 
-		if strings.HasPrefix(name, "master_replid") {
+		if strings.HasPrefix(name, "main_replid") {
 			continue
 		}
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.